### PR TITLE
Fix typo in Form.handlePasswordChange().

### DIFF
--- a/assets/build/options.js
+++ b/assets/build/options.js
@@ -57,7 +57,7 @@ var Form = React.createClass({displayName: "Form",
   handlePasswordChange: function(event){
     var password = event.target.value;
     localStorage["password"] = password;
-    this.setState({desk: password});
+    this.setState({password: password});
     this.flashInfo();
     this.setDeskHash();
   },

--- a/assets/src/options.js
+++ b/assets/src/options.js
@@ -57,7 +57,7 @@ var Form = React.createClass({
   handlePasswordChange: function(event){
     var password = event.target.value;
     localStorage["password"] = password;
-    this.setState({desk: password});
+    this.setState({password: password});
     this.flashInfo();
     this.setDeskHash();
   },


### PR DESCRIPTION
In options.js the handlePasswordChange method had a typo causing the password input to be set as the desk. The PR fixes the typo.