### PR TITLE
Fix link

### DIFF
--- a/assets/build/links.js
+++ b/assets/build/links.js
@@ -42,8 +42,8 @@ Links.main = [{
     url: "https://github.com/appacademy/curriculum/blob/master/react",
     start: 71
   }, {
-    title: "Capstone",
-    url: "https://github.com/appacademy/capstone-project-curriculum",
+    title: "Full Stack",
+    url: "https://github.com/appacademy/curriculum/blob/master/full-stack-project",
     start: 81
   }, {
     title: "Jobs",


### PR DESCRIPTION
Hi SF!

I found a link in the chrome tab which is pointing to the wrong repo.

I only fixed the `build` file because it looks like the `src` files are mostly out of date (there's still discourage.js and old links). Is the `src` folder still relevant? Should I update the links there too? 